### PR TITLE
Fix infinite loops when reloading observed fragments

### DIFF
--- a/packages/model-fragments/lib/fragments/attributes.js
+++ b/packages/model-fragments/lib/fragments/attributes.js
@@ -79,8 +79,10 @@ function hasOneFragment(declaredTypeName, options) {
     // Else initialize the fragment
     } else if (data && data !== fragment) {
       fragment || (fragment = setOwner(store.buildFragment(actualTypeName)));
-      fragment.setupData(data);
+      //Make sure to first cache the fragment before calling setupData, so if setupData causes this CP to be accessed
+      //again we have it cached already
       this._data[key] = fragment;
+      fragment.setupData(data);
     } else {
       // Handle the adapter setting the fragment to null
       fragment = data;
@@ -194,8 +196,8 @@ function hasManyFragments(declaredTypeName, options) {
     // Create a fragment array and initialize with data
     } else if (data && data !== fragments) {
       fragments || (fragments = createArray());
-      fragments.setupData(data);
       this._data[key] = fragments;
+      fragments.setupData(data);
     } else {
       // Handle the adapter setting the fragment array to null
       fragments = data;


### PR DESCRIPTION
Currently in certain annoying cases in Ember, including aliases or proxies that are actively observed,
CPs are consumed as soon as they are changed. This used to cause an infinite loop. For example:

If you had
```
  App.User = DS.Model.extend({
    name: hasOneFragment('name')
  })

  App.Name = DS.ModelFragment.extend({
    firstName: DS.attr()
  })
```

1. We would push new data for a user
2. We would notify a change for the user.name which cleared the fragments cache
3. An observer would try to get `user.name.firstName` synchronously
4. As we had new data, we would try to setupData on the fragment
5. In the middle of fragment data setup we would notify a change to `firstName`
6. The observer would fire immediately and try to get `user.name.firstName` even though
  we weren't done with the setup
7. Goto 4

We now cache the fragment early enough to prevent this infinite loop