### PR TITLE
Snapshot update (beta.15 compatibility)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,12 +21,11 @@
     "test.html.mustache"
   ],
   "dependencies": {
-    "ember": "^1.4.0",
-    "ember-data": "^1.0.0-beta.14"
+    "ember-data": "^1.0.0-beta.15"
   },
   "devDependencies": {
     "qunit": "^1.14.0",
     "jquery": "^2.0.0",
-    "ember": "^1.4.0"
+    "ember": "^1.10.0"
   }
 }

--- a/packages/model-fragments/lib/core-model.js
+++ b/packages/model-fragments/lib/core-model.js
@@ -13,6 +13,7 @@ Model.proto();
 var protoProps = [
   '_setup',
   '_unhandledEvent',
+  '_createSnapshot',
   'send',
   'transitionTo',
   'isEmpty',

--- a/packages/model-fragments/lib/fragments/array/fragment.js
+++ b/packages/model-fragments/lib/fragments/array/fragment.js
@@ -79,6 +79,17 @@ var FragmentArray = StatefulArray.extend({
   },
 
   /**
+    @method _createSnapshot
+    @private
+  */
+  _createSnapshot: function() {
+    // Snapshot each fragment
+    return map(this, function(fragment) {
+      return fragment._createSnapshot();
+    });
+  },
+
+  /**
     @method adapterDidCommit
   */
   adapterDidCommit: function() {

--- a/packages/model-fragments/lib/fragments/array/stateful.js
+++ b/packages/model-fragments/lib/fragments/array/stateful.js
@@ -81,6 +81,15 @@ var StatefulArray = Ember.ArrayProxy.extend({
   },
 
   /**
+    @method _createSnapshot
+    @private
+  */
+  _createSnapshot: function() {
+    // Since elements are not models, a snapshot is simply a mapping of raw values
+    return this.toArray();
+  },
+
+  /**
     @method adapterDidCommit
   */
   adapterDidCommit: function() {

--- a/packages/model-fragments/lib/fragments/ext.js
+++ b/packages/model-fragments/lib/fragments/ext.js
@@ -78,6 +78,30 @@ Model.reopen({
   },
 
   /**
+    Override parent method to snapshot fragment attributes before they are
+    passed to the `DS.Model#serialize`.
+
+    @method _createSnapshot
+    @private
+  */
+  _createSnapshot: function() {
+    var snapshot = this._super.apply(this, arguments);
+    var attrs = snapshot._attributes;
+
+    Ember.keys(attrs).forEach(function(key) {
+      var attr = attrs[key];
+
+      // If the attribute has a `_createSnapshot` method, invoke it before the
+      // snapshot gets passed to the serializer
+      if (attr && typeof attr._createSnapshot === 'function') {
+        attrs[key] = attr._createSnapshot();
+      }
+    });
+
+    return snapshot;
+  },
+
+  /**
     If the adapter did not return a hash in response to a commit,
     merge the changed attributes and relationships into the existing
     saved data and notify all fragments of the commit.

--- a/packages/model-fragments/lib/fragments/transform.js
+++ b/packages/model-fragments/lib/fragments/transform.js
@@ -1,8 +1,13 @@
+import Snapshot from '../snapshot';
 import Transform from '../transform';
 
 /**
   @module ember-data.model-fragments
 */
+
+var get = Ember.get;
+var isArray = Ember.isArray;
+var map = Ember.EnumerableUtils.map;
 
 /**
   Transform for all fragment attributes which delegates work to
@@ -19,9 +24,24 @@ var FragmentTransform = Transform.extend({
     return data;
   },
 
-  serialize: function(fragment) {
-    return fragment ? fragment.serialize() : null;
+  serialize: function(snapshot) {
+    if (!snapshot) {
+      return null;
+    } else if (isArray(snapshot)) {
+      return map(snapshot, serializeSnapshot);
+    } else {
+      return serializeSnapshot(snapshot);
+    }
   }
 });
+
+function serializeSnapshot(snapshot) {
+  // The snapshot can be a primitive value (which could be an object)
+  if (!(snapshot instanceof Snapshot)) {
+    return snapshot;
+  }
+
+  return get(snapshot, 'record.store').serializerFor(snapshot.typeKey).serialize(snapshot);
+}
 
 export default FragmentTransform;

--- a/packages/model-fragments/lib/snapshot.js
+++ b/packages/model-fragments/lib/snapshot.js
@@ -1,0 +1,1 @@
+export default DS.Snapshot;

--- a/packages/model-fragments/tests/unit/fragment_test.js
+++ b/packages/model-fragments/tests/unit/fragment_test.js
@@ -1,4 +1,4 @@
-var env, store, Person, Name;
+var env, store, Person, Name, House;
 var all = Ember.RSVP.all;
 
 module("unit/fragments - DS.ModelFragment", {
@@ -12,9 +12,16 @@ module("unit/fragments - DS.ModelFragment", {
       last  : DS.attr("string")
     });
 
+    House = DS.ModelFragment.extend({
+      name   : DS.attr("string"),
+      region : DS.attr("string"),
+      exiled : DS.attr("boolean")
+    });
+
     env = setupStore({
       person: Person,
-      name: Name
+      name: Name,
+      house: House
     });
 
     store = env.store;
@@ -156,4 +163,66 @@ test("fragment properties are serialized as normal attributes using their own se
 
     equal(serialized.name, 'Mad King', "serialization uses result from `fragment#serialize`");
   }));
+});
+
+test("fragment properties are snapshotted as normal attributes on the owner record snapshot", function() {
+  expect(7);
+
+  // TODO: this is necessary to set `typeKey` and prevent `store#serializerFor` from blowing up
+  store.modelFor('person');
+
+  Person.reopen({
+    houses   : DS.hasManyFragments('house'),
+    children : DS.hasManyFragments()
+  });
+
+  var person = {
+    id: 1,
+    name: {
+      first : "Catelyn",
+      last  : "Stark"
+    },
+    houses: [
+      {
+        name   : "Tully",
+        region : "Riverlands",
+        exiled : true
+      },
+      {
+        name   : "Stark",
+        region : "North",
+        exiled : true
+      }
+    ],
+    children: [
+      'Robb',
+      'Sansa',
+      'Arya',
+      'Brandon',
+      'Rickon'
+    ]
+  };
+
+  store.push('person', person);
+
+  env.container.register('serializer:person', DS.JSONSerializer.extend({
+    serialize: function(snapshot) {
+      var name = snapshot.attr('name');
+      ok(name instanceof DS.Snapshot, "`hasOneFragment` snapshot attribute is a snapshot");
+      equal(name.attr('first'), person.name.first, "`hasOneFragment` attributes are snapshoted correctly");
+
+      var houses = snapshot.attr('houses');
+      ok(Array.isArray(houses), "`hasManyFragments` attribute is an array");
+      ok(houses[0] instanceof DS.Snapshot, "`hasManyFragments` attribute is an array of snapshots");
+      equal(houses[0].attr('name'), person.houses[0].name, "`hasManyFragments` attributes are snapshotted correctly");
+
+      var children = snapshot.attr('children');
+      ok(Array.isArray(children), "primitive `hasManyFragments` attribute is an array");
+      deepEqual(children, person.children, "primitive `hasManyFragments` attribute is snapshotted correctly");
+    }
+  }));
+
+  return store.find('person', 1).then(function(person) {
+    person.serialize();
+  });
 });

--- a/test.html.mustache
+++ b/test.html.mustache
@@ -12,7 +12,7 @@
   <script src="/testem.js"></script>
   <script src="bower_components/jquery/dist/jquery.js"></script>
   <script src="bower_components/handlebars/handlebars.js"></script>
-  <script src="bower_components/ember/ember.js"></script>
+  <script src="bower_components/ember/ember.debug.js"></script>
   <script src="bower_components/ember-data/ember-data.js"></script>
   {{#serve_files}}
   <script src="{{src}}"></script>


### PR DESCRIPTION
The change to passing snapshots to serializers instead of records has interesting implications for model fragments. At their core, fragments are simply embedded JSON attributes, so from the perspective of a snapshot, they should be considered attributes and _not_ relationships. The `hasOneFragment` and `hasManyFragments` properties are already marked as attributes, but when creating a new snapshot, the fragment model/array instance is returned when calling `snapshot#attr` – not exactly a snapshot of the attributes.

Therefore fragments need to be serialized in the snapshot _before_ `DS.Model#serialize` is invoked, instead of afterwards when transforms are applied to attributes. This unfortunately means relying on even more private APIs, in this case `DS.Model#_createSnapshot` (since the Snapshot constructor is not easy to override).

@wecc I don't know how familiar you are with this project, but if you could look over where I'm hooking into snapshots, I'd love to get your feedback!