### PR TITLE
Allow easier unit/integration testing from ember-cli.

### DIFF
--- a/ember-addon/app/transforms/fragment.js
+++ b/ember-addon/app/transforms/fragment.js
@@ -1,0 +1,1 @@
+export default DS.FragmentTransform;


### PR DESCRIPTION
This allows the normal resolver to find `transform:fragment` when using `moduleForModel` either with `needs: [ 'transform:fragment' ]` or with `integration: true`.

Fixes https://github.com/lytics/ember-data.model-fragments/issues/80.
Fixes https://github.com/lytics/ember-data.model-fragments/pull/87.