### PR TITLE
deep copy fragments

### DIFF
--- a/packages/model-fragments/lib/fragments/model.js
+++ b/packages/model-fragments/lib/fragments/model.js
@@ -170,13 +170,10 @@ var ModelFragment = CoreModel.extend(Ember.Comparable, Ember.Copyable, {
   copy: function() {
     var store = get(this, 'store');
     var type = store.modelFor(this.constructor);
-    var data = {};
-
-    // TODO: handle copying sub-fragments
-    Ember.merge(data, this._data);
-    Ember.merge(data, this._attributes);
-
-    return this.store.createFragment(type, data);
+    var data = this.serialize();
+    var result = this.store.createFragment(type);
+    result.setupData(data);
+    return result;
   },
 
   /**


### PR DESCRIPTION
I believe the expected behavior for copying fragments would be to clone the entire fragment tree.  Right now `fragment.copy()` does not handle nested fragments this way.  My approach is simple: serialize the fragment to make the deep copy, then create a new fragment and deserialize it.
