### PR TITLE
Established values are no longer clobbered by defaultValue

### DIFF
--- a/packages/model-fragments/tests/unit/default_value_test.js
+++ b/packages/model-fragments/tests/unit/default_value_test.js
@@ -1,0 +1,87 @@
+var env, store, Person;
+
+QUnit.module("unit/fragments - Default Values", {
+  setup: function() {
+    Person = DS.ModelFragment.extend({
+      firstName : DS.attr("string", { defaultValue: 'Bob' }),
+      lastName  : DS.attr("string"),
+      title     : DS.attr("string", { defaultValue: null }),
+      company   : DS.attr("string", { defaultValue: undefined }),
+      employed  : DS.attr("boolean", { defaultValue: false })
+    });
+
+    env = setupEnv({
+      person: Person,
+    });
+
+    store = env.store;
+  },
+
+  teardown: function() {
+    env = null;
+    store = null;
+    Person = null;
+  }
+});
+
+test("default values are used when no values are specified in the payload", function() {
+  store.push({
+    type: 'person',
+    id: 1,
+    attributes: {}
+  });
+
+  return store.find('person', 1).then(function(person) {
+    equal(person.get('firstName'), 'Bob', "truthy default value is used");
+    equal(person.get('lastName'), undefined, "no default value returns undefined");
+    equal(person.get('title'), null, "a default value of null returns null");
+    equal(person.get('company'), undefined, "a default value of undefined returns undefined");
+    equal(person.get('employed'), false, "a default value of false returns false");
+  });
+});
+
+test("values in the payload override default values", function() {
+  store.push({
+    type: 'person',
+    id: 1,
+    attributes: {
+      firstName: undefined,
+      lastName:  'Smith',
+      company: null
+    }
+  });
+
+  return store.find('person', 1).then(function(person) {
+    equal(person.get('firstName'), undefined, "setting to undefined overrides the default value");
+    equal(person.get('lastName'), 'Smith', "setting to a truthy value overrides the default value");
+    equal(person.get('company'), null, "setting to null overrides the default value");
+  });
+});
+
+test("default values are overridden when the property is set", function() {
+  store.push({
+    type: 'person',
+    id: 1,
+    attributes: {}
+  });
+
+  return store.find('person', 1).then(function(person) {
+    person.set('firstName', 'Ted');
+    equal(person.get('firstName'), 'Ted', "default value is overridden when the property is set");
+  });
+});
+
+test("default values are not used when the value is set to a falsy value", function() {
+  store.push({
+    type: 'person',
+    id: 1,
+    attributes: {}
+  });
+
+  return store.find('person', 1).then(function(person) {
+    person.set('firstName', null);
+    equal(person.get('firstName'), null, "default value is not used when the value is set to null");
+    person.set('firstName', undefined);
+    equal(person.get('firstName'), undefined, "default value is not used when the value is set to undefined");
+  });
+});

--- a/packages/model-fragments/tests/unit/fragments/has_many_test.js
+++ b/packages/model-fragments/tests/unit/fragments/has_many_test.js
@@ -250,7 +250,13 @@ test("fragments can have default values", function() {
 
   var throne = store.createRecord('throne', { name: 'Iron' });
 
-  equal(throne.get('addresses.firstObject.street'), defaultValue[0].street, "the default value is correct");
+  equal(throne.get('addresses.firstObject.street'), defaultValue[0].street, "the default value is used when the value has not been specified");
+
+  throne.set('addresses', null);
+  equal(throne.get('addresses'), null, "the default value is not used when the value is set to null");
+
+  throne = store.createRecord('throne', { name: 'Iron', addresses: null });
+  equal(throne.get('addresses'), null, "the default value is not used when the value is initialized to null");
 });
 
 test("fragment default values can be functions", function() {

--- a/packages/model-fragments/tests/unit/fragments/has_one_test.js
+++ b/packages/model-fragments/tests/unit/fragments/has_one_test.js
@@ -157,7 +157,13 @@ test("fragments can have default values", function() {
 
   var ship = store.createRecord('ship');
 
-  equal(ship.get('name.first'), defaultValue.first, "the default value is correct");
+  equal(ship.get('name.first'), defaultValue.first, "the default value is used when the value has not been specified");
+
+  ship.set('name', null);
+  equal(ship.get('name'), null, "the default value is not used when the value is set to null");
+
+  ship = store.createRecord('ship', { name: null });
+  equal(ship.get('name'), null, "the default value is not used when the value is initialized to null");
 });
 
 test("fragment default values can be functions", function() {


### PR DESCRIPTION
Fixes #138.  Added some basic `defaultValue` tests as well.

Once this is merged into master, I'll rebase #127, and hopefully we can get that one in too.