### PR TITLE
Use public registry.

### DIFF
--- a/packages/model-fragments/lib/fragments/ext.js
+++ b/packages/model-fragments/lib/fragments/ext.js
@@ -234,7 +234,7 @@ JSONSerializer.reopen({
 
 // Retrieve or create a transform for the specific fragment type
 function getFragmentTransform(container, store, attributeType) {
-  var registry = container._registry || container;
+  var registry = container._registry || container.registry || container;
   var containerKey = 'transform:' + attributeType;
   var match = attributeType.match(/^-mf-(fragment|fragment-array|array)(?:\$([^$]+))?(?:\$(.+))?$/);
   var transformType = match[1];


### PR DESCRIPTION
Since Ember 2.1 `registry` is public.

See emberjs/ember.js#11440.

Closes #141
