### PR TITLE
Changed default fragment serializer to use store default

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ App.NameSerializer = DS.JSONSerializer.extend({
 });
 ```
 
+Since fragment deserialization uses the value of a single attribute in the parent model, the `normalizeResponse` method of the serializer is never used. And since the attribute value is not a full-fledged [JSON API](http://jsonapi.org/) response, `DS.JSONAPISerializer` cannot be used with fragments. Because of this, auto-generated fragment serializers **do not use the application serializer** and instead use `DS.JSONSerializer`. If common logic must be added to auto-generated fragment serializers, apps can register a custom `serializer:-fragment` with the application in an initializer.
+
 If custom serialization of the owner record is needed, fragment [snapshots](http://emberjs.com/api/data/classes/DS.Snapshot.html) can be accessed using the [`Snapshot#attr`](http://emberjs.com/api/data/classes/DS.Snapshot.html#method_attr) method. Note that this differs from how relationships are accessed on snapshots (using `belongsTo`/`hasMany` methods):
 
 ```javascript

--- a/packages/model-fragments/lib/fragments/ext.js
+++ b/packages/model-fragments/lib/fragments/ext.js
@@ -65,6 +65,40 @@ Store.reopen({
     fragment._isFragment = true;
 
     return fragment;
+  },
+
+  /**
+    Changes serializer fallbacks for fragments to use `serializer:-fragment`
+    if registered, then uses the default serializer.
+
+    @method serializerFor
+    @private
+    @param {String} modelName the record to serialize
+    @return {DS.Serializer}
+  */
+  serializerFor: function(modelOrClass) {
+    var modelName;
+
+    if (typeof modelOrClass === 'string') {
+      modelName = modelOrClass;
+    } else {
+      modelName = modelOrClass.modelName;
+    }
+
+    var type = this.modelFor(modelName);
+
+    // For fragments, don't use the application serializer or adapter default
+    // as a fallbacks
+    if (Fragment.detect(type)) {
+      var fallbacks = [
+        '-fragment',
+        '-default'
+      ];
+
+      return this.lookupSerializer(modelName, fallbacks);
+    }
+
+    return this._super(modelOrClass);
   }
 });
 

--- a/packages/model-fragments/tests/unit/store_test.js
+++ b/packages/model-fragments/tests/unit/store_test.js
@@ -40,3 +40,25 @@ test("attempting to create a fragment type that does not inherit from `MF.Fragme
     store.createFragment('person');
   }, "an error is thrown when given a bad type");
 });
+
+test("the default fragment serializer does not use the application serializer", function() {
+  var Serializer = DS.JSONAPISerializer.extend();
+  env.registry.register('serializer:application', Serializer);
+
+  ok(!(store.serializerFor('name') instanceof Serializer), "fragment serializer fallback is not `DS.JSONAPISerializer`");
+  ok(store.serializerFor('name') instanceof DS.JSONSerializer, "fragment serializer fallback is correct");
+});
+
+test("the default fragment serializer does not use the adapter's `defaultSerializer`", function() {
+  env.adapter.set('defaultSerializer', '-json-api');
+
+  ok(!(store.serializerFor('name') instanceof DS.JSONAPISerializer), "fragment serializer fallback is not `DS.JSONAPISerializer`");
+  ok(store.serializerFor('name') instanceof DS.JSONSerializer, "fragment serializer fallback is correct");
+});
+
+test("the default fragment serializer is `serializer:-fragment` if registered", function() {
+  var Serializer = DS.JSONSerializer.extend();
+  env.registry.register('serializer:-fragment', Serializer);
+
+  ok(store.serializerFor('name') instanceof Serializer, "fragment serializer fallback is correct");
+});


### PR DESCRIPTION
Closes #135

This changes the behavior of `store.serializerFor` to skip `serializer:application` and the default adapter's `defaultSerializer` property. It will also use `serializer:-fragment` if registered as a convenience for apps that want a serializer that is different from the application serializer, but do not want to create a boilerplate serializer class for every fragment class. Prefixing it with a dash requires devs to register it in a custom initializer, but it avoids potential naming clashes.

This is a breaking change since many apps may rely on using the application serializer as the default fragment serializer, and will be part of the 1.0 release.

cc @dfreeman