### PR TITLE
Revert fragment owner reseting

### DIFF
--- a/packages/model-fragments/lib/fragments/array/fragment.js
+++ b/packages/model-fragments/lib/fragments/array/fragment.js
@@ -185,13 +185,6 @@ var FragmentArray = StatefulArray.extend({
     var replacedContent = content.slice(index, index + amount);
     var fragments = normalizeFragmentArray(this, replacedContent, objs);
 
-    // If fragments get removed from the array, clear their owners
-    if (fragments.length < replacedContent.length) {
-      replacedContent.slice(fragments.length).forEach(function(fragment) {
-        setFragmentOwner(fragment, null, null);
-      });
-    }
-
     return content.replace(index, amount, fragments);
   },
 

--- a/packages/model-fragments/lib/fragments/attributes.js
+++ b/packages/model-fragments/lib/fragments/attributes.js
@@ -116,7 +116,6 @@ function fragment(declaredModelName, options) {
   function setFragmentValue(record, key, fragment, value) {
     var store = record.store;
     var internalModel = internalModelFor(record);
-    var originalFragment = fragment;
 
     Ember.assert("You can only assign `null`, an object literal or a '" + declaredModelName + "' fragment instance to this property", value === null || typeOf(value) === 'object' || isInstanceOfType(store.modelFor(declaredModelName), value));
 
@@ -133,12 +132,6 @@ function fragment(declaredModelName, options) {
       // The fragment already exists and a property hash is given, so just set
       // its values and let the state machine take care of the dirtiness
       return setProperties(fragment, value);
-    }
-
-    if (originalFragment && fragment !== originalFragment) {
-      // Since the original fragment no longer belongs to the record, free it
-      // of its owner record
-      setFragmentOwner(originalFragment, null, null);
     }
 
     if (internalModel._data[key] !== fragment) {

--- a/packages/model-fragments/lib/fragments/attributes.js
+++ b/packages/model-fragments/lib/fragments/attributes.js
@@ -349,7 +349,7 @@ function fragmentArrayProperty(metaType, options, createArray) {
 */
 function fragmentOwner() {
   return computed(function() {
-    Ember.assert("Fragment owner properties can only be used on fragments.", this._isFragment);
+    Ember.assert("Fragment owner properties can only be used on fragments.", isFragment(this));
 
     return internalModelFor(this)._owner;
   }).meta({

--- a/packages/model-fragments/lib/fragments/fragment.js
+++ b/packages/model-fragments/lib/fragments/fragment.js
@@ -173,7 +173,7 @@ export function internalModelFor(record) {
 export function setFragmentOwner(fragment, record, key) {
   var internalModel = internalModelFor(fragment);
 
-  Ember.assert("Fragments can only belong to one owner, try copying instead", !record || !internalModel._owner || internalModel._owner === record);
+  Ember.assert("To preserve rollback semantics, fragments can only belong to one owner. Try copying instead", !internalModel._owner || internalModel._owner === record);
 
   internalModel._owner = record;
   internalModel._name = key;

--- a/packages/model-fragments/tests/integration/dependent_state_test.js
+++ b/packages/model-fragments/tests/integration/dependent_state_test.js
@@ -12,7 +12,8 @@ QUnit.module("integration - Dependent State", {
 
     Name = MF.Fragment.extend({
       first: DS.attr('string'),
-      last: DS.attr('string')
+      last: DS.attr('string'),
+      person: MF.fragmentOwner()
     });
 
     Address = MF.Fragment.extend({
@@ -282,6 +283,29 @@ test("rolling back a fragment returns the fragment and the owner record to a cle
 
     ok(!name.get('hasDirtyAttributes'), "fragment is clean");
     ok(!person.get('hasDirtyAttributes'), "owner record is clean");
+  });
+});
+
+test("changing a fragment property then rolling back the owner record preserves the fragment's owner", function() {
+  store.push({
+    type: 'person',
+    id: 1,
+    attributes: {
+      name: {
+        first: "Arya",
+        last: "Stark"
+      }
+    }
+  });
+
+  return store.find('person', 1).then(function(person) {
+    var name = person.get('name');
+
+    person.set('name', null);
+
+    person.rollbackAttributes();
+
+    equal(name.get('person'), person, "fragment owner is preserved");
   });
 });
 

--- a/packages/model-fragments/tests/unit/fragment_owner_property_test.js
+++ b/packages/model-fragments/tests/unit/fragment_owner_property_test.js
@@ -97,76 +97,28 @@ test("attempting to change a fragment's owner record throws an error", function(
   });
 });
 
-test("setting a fragment property to `null` releases it of its owner record", function() {
+test("fragment owner properties are notified of change", function() {
   store.push({
     type: 'person',
     id: 1,
     attributes: {
       name: {
-        first: 'Sandor',
-        last: 'Clegane'
+        first: "Jeyne",
+        last: "Poole"
       }
     }
   });
 
   return store.find('person', 1).then(function(person) {
-    var name = person.get('name');
-
-    person.set('name', null);
-
-    ok(!name.get('person'), "fragment owner is cleared");
-
-    var newPerson = store.createRecord('person', {
-      name: name
+    var name = store.createFragment('name', {
+      first: 'Arya',
+      last: 'Stark'
     });
 
-    equal(name.get('person'), newPerson, "fragment owner is set");
-  });
-});
+    ok(!name.get('person'), "fragment owner property is null");
 
-test("removing a fragment from an array property to `null` releases it of its owner record", function() {
-  Person.reopen({
-    names: MF.fragmentArray('name')
-  });
+    person.set('name', name);
 
-  store.push({
-    type: 'person',
-    id: 1,
-    attributes: {
-      names: [
-        {
-          first: 'Jaqen ',
-          last: 'H\'ghar'
-        },
-        {
-          first: 'The',
-          last: 'Alchemist'
-        },
-        {
-          first: '',
-          last: ''
-        }
-      ]
-    }
-  });
-
-  return store.find('person', 1).then(function(person) {
-    var names = person.get('names');
-    var name1 = names.objectAt(0);
-    var name2 = names.objectAt(1);
-    var name3 = names.objectAt(2);
-
-    names.removeObject(name1);
-    names.replace(0, 2, []);
-
-    ok(!name1.get('person'), "fragment owner is cleared (1)");
-    ok(!name2.get('person'), "fragment owner is cleared (2)");
-    ok(!name3.get('person'), "fragment owner is cleared (3)");
-
-    var newPerson = store.createRecord('person', {
-      names: [ name1 ]
-    });
-
-    equal(name1.get('person'), newPerson, "fragment owner is set");
+    equal(name.get('person'), person, "fragment owner property is updated");
   });
 });


### PR DESCRIPTION
This reverts the behavior described in #133. It turns out there was a very good reason for only ever allowing a fragment to belong to one owner: it prevents conflicts when rolling back a record with fragments:

```js
var fragment = record1.get('fragment');

record1.set('fragment', null); // Previously, this cleared the fragment's owner

record2.set('fragment', fragment); // Possible, since the fragment has no owner

record1.rollback();

fragment.get('owner'); // ???
```

this is a breaking change for anyone that has upgraded to v0.4.2 or v0.4.3 and now relies on this behavior. However, since chances of that are small, and this was an oversight on my part and introduces a bug, this should be treated as like a bugfix (no minor version number bump).

@martinthogersen I'm curious if you've updated to use this behavior yet. 